### PR TITLE
Spawn commands correctly on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const child_process = require("child_process");
 const stringArgv = require("string-argv");
 const emptyDir = require("empty-dir");
 const crypto = require("crypto");
+const os = require("os");
 
 class ServerlessRack {
   validate() {
@@ -379,7 +380,8 @@ class ServerlessRack {
           args.push(...this.dockerArgs);
 
           const res = child_process.spawnSync("docker", args, {
-            stdio: "inherit"
+            stdio: "inherit",
+            shell: os.platform() === 'win32'
           });
           if (res.error) {
             if (res.error.code == "ENOENT") {
@@ -404,7 +406,7 @@ class ServerlessRack {
           args.push(...stringArgv.parseArgsStringToArgv(this.bundlerArgs));
         }
 
-        const res = child_process.spawnSync(this.bundlerBin, args);
+        const res = child_process.spawnSync(this.bundlerBin, args, {shell: os.platform() === 'win32'});
         if (res.error) {
           if (res.error.code == "ENOENT") {
             return reject(


### PR DESCRIPTION
On Windows, `spawn` always gives an ENOENT error even if `bundle` is in the path, because the real filename is `bundle.exe`, `bundle.cmd`, or `bundle.bat`. The `shell` option makes Node.js execute it via a shell, which will then find the correct file and extension. See [the docs](https://nodejs.org/api/child_process.html#spawning-bat-and-cmd-files-on-windows).